### PR TITLE
Changed the readme to reflect Ruby version Gemfile stuff

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby "2.4.3"
+ruby "2.2.4"
 
 gem "jekyll"
 gem "jekyll-watch"

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source "https://rubygems.org"
 
-ruby "2.2.4"
+ruby "2.4.3"
 
 gem "jekyll"
 gem "jekyll-watch"
 gem "kramdown"
-gem "scss-lint"
+gem "scss_lint"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ $ npm install -g gulp
 $ gem install bundler
 ```
 
+Make sure that the Gemfile reflects your system's current Ruby version. If it doesn't, make sure to change the Gemfile to reflect your Ruby version.
+
+```bash
+$ ruby -v
+```
+
+Write down the Ruby version you see.
+
+```
+// inside ./Gemfile
+...
+-ruby "2.2.4" // change this to the current Ruby version, ignoring anything past the release number.
+...
+```
+
 Now let's install the development dependencies by running the NPM installer and
 bundler:
 


### PR DESCRIPTION
Was using this repo on Windows so we don't have access to an easy Ruby manager. The simplest fix was to determine the Ruby version and update it in the Gemfile.

Also, apparently scss-lint doesn't exist in gem any longer and has been renamed to scss_lint.